### PR TITLE
docs: add root and per-package READMEs, MIT license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2026 Fabien Marie-Louise
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,137 @@
+# hope-ui
+
+**hope-ui** is a component library for [SolidJS](https://www.solidjs.com/) 2.0. Import a component
+and it works — accessible, keyboard-friendly, and styled out of the box. It's the
+batteries-included option (in the spirit of MUI or Mantine) that the Solid ecosystem has been
+missing, not a headless or copy-paste kit.
+
+Components are styled with **Tailwind v4** and built on an internal headless kernel that handles the
+hard parts — focus, keyboard navigation, dismissal, and accessibility — so you don't have to think
+about any of it to use them.
+
+- **Documentation:** [hope-ui.dev](https://hope-ui.dev) *(not published yet)*
+- **Storybook:** [storybook.hope-ui.dev](https://storybook.hope-ui.dev)
+
+## Status
+
+Pre-release and **not published yet**. hope-ui targets `solid-js@2.0.0-beta.x` (pinned via the
+`pnpm-workspace.yaml` catalog), and the release model is: build on the pinned beta → wait for
+SolidJS 2.0 stable → fix the beta→stable breakage → publish 1.0. Nothing ships to npm before 2.0
+stable lands. See [`docs/plan.md`](docs/plan.md) for the architecture and phased plan, and
+[`docs/roadmap.md`](docs/roadmap.md) for the component backlog.
+
+## Packages
+
+This is a pnpm + Turborepo workspace. Every package lives under [`packages/`](packages/).
+
+| Package | Role |
+| ------- | ---- |
+| [`@hope-ui/components`](packages/components/README.md) | Public components, one subpath export each (`@hope-ui/components/button`, `.../dialog`, …). The product. |
+| [`@hope-ui/primitives`](packages/primitives/README.md) | The headless behavior kernel — **internal / advanced escape hatch**, not a stability-promised API. Everything else composes it. |
+| [`@hope-ui/theming`](packages/theming/README.md) | The theming contract and dependency-inversion seam: `ThemeProvider`/`useRecipe`, the `RecipeRegistry`, the semantic-token vocabulary, and the `tv`/`cn`/`cx` styling seam. |
+| [`@hope-ui/presets`](packages/presets/README.md) | The default visual identity, `@hope-ui/presets/hope` — design tokens (a Tailwind CSS entry) plus a runtime recipe map. |
+| [`@hope-ui/internal-test-utils`](packages/internal-test-utils/README.md) | Private shared test harness (`mount` + `expectNoA11yViolations` + `hydrateFixture`). Not published. |
+
+Runtime dependency direction: `@hope-ui/primitives` ← `@hope-ui/theming` ← `@hope-ui/components`.
+Presets depend *up* on `@hope-ui/theming` for the contract they implement. Components read recipes
+through theming; presets implement them; neither knows about the other.
+
+## Getting started
+
+> Not yet on npm — this section describes the intended install for when 1.0 ships.
+
+```bash
+pnpm add @hope-ui/components @hope-ui/theming @hope-ui/presets
+```
+
+A SolidJS 2.0 app wires up the default preset once, then uses components anywhere below the
+provider:
+
+```tsx
+// app entry CSS (imported by your Tailwind v4 entry)
+// @import "tailwindcss";
+// @import "@hope-ui/presets/hope/tailwind.css";
+
+import { ThemeProvider } from "@hope-ui/theming";
+import { hope } from "@hope-ui/presets/hope";
+import { Button } from "@hope-ui/components/button";
+
+function App() {
+  return (
+    <ThemeProvider preset={hope}>
+      <Button colorScheme="primary" variant="solid">
+        Save
+      </Button>
+    </ThemeProvider>
+  );
+}
+```
+
+`@import "@hope-ui/presets/hope/tailwind.css"` supplies the `--hope-*` design tokens and their
+mapping to clean utilities (`bg-primary`, `text-on-primary`, …); `<ThemeProvider preset={hope}>`
+gives components their recipes at runtime. `hope` is a **zero-DOM preset** — the provider renders
+no markup of its own. See [`docs/theming.md`](docs/theming.md).
+
+## Development
+
+```bash
+pnpm install              # install workspace deps
+pnpm build                # turbo: build all packages (tsdown → JSX-preserved .jsx + .d.ts per subpath)
+pnpm lint                 # biome check .
+pnpm format               # biome format --write .
+pnpm typecheck            # turbo: tsc --noEmit per package (resolves siblings to src, never dist)
+pnpm test                 # vitest run --project=unit    (node, no DOM, pure logic)
+pnpm test:ssr             # vitest run --project=ssr     (node, SERVER builds of solid-js + @solidjs/web)
+pnpm test:browser         # vitest run --project=browser (real Chromium, DOM + hydration)
+pnpm storybook            # visual harness on :6006
+pnpm build:storybook      # static Storybook build (also the CI smoke test for the config)
+pnpm check:coverage-parity  # fails if a src file lacks a test / usage doc / story, or a leaf folder sprawls
+```
+
+The three Vitest projects are split by **module resolution**, not by taste — `unit` (client
+builds, no DOM), `ssr` (server builds of both `solid-js` and `@solidjs/web`), `browser` (real
+Chromium via Playwright). Playwright's browser is installed once (CI does this automatically):
+
+```bash
+pnpm exec playwright install --only-shell chromium
+```
+
+Run a single test file or a single test:
+
+```bash
+pnpm exec vitest run --project=browser packages/components/src/button/__tests__/button.browser.test.tsx
+pnpm exec vitest run --project=browser -t "fires onClick"
+```
+
+See [`docs/testing.md`](docs/testing.md) before writing any test.
+
+## Repository layout
+
+```
+packages/
+  components/            @hope-ui/components  — public components (subpath per component)
+  primitives/            @hope-ui/primitives  — headless behavior kernel
+  theming/               @hope-ui/theming     — theming contract + conformance kit
+  presets/               @hope-ui/presets     — presets (hope = default)
+  internal-test-utils/   @hope-ui/internal-test-utils — private test harness
+docs/                    architecture, theming, testing, roadmap, and per-file usage docs
+  usage/<pkg>/<path>/     per-source-file API docs, mirroring package + src path
+scripts/                 check-coverage-parity.mjs and other repo tooling
+.storybook/              Storybook config (shares one Solid compiler config with the tests)
+```
+
+## Contributing
+
+Every source file under `packages/*/src/` (except `index.ts`) ships with a matching test, a usage
+`.md` under `docs/usage/`, and — for `@hope-ui/components` — a colocated Storybook story. This
+**Definition of Done** is CI-enforced by `pnpm check:coverage-parity`; the full rules and rationale
+are in [`docs/definition-of-done.md`](docs/definition-of-done.md), [`docs/testing.md`](docs/testing.md),
+and [`CLAUDE.md`](CLAUDE.md). Deeper background lives in [`docs/plan.md`](docs/plan.md),
+[`docs/theming.md`](docs/theming.md), and [`docs/solid-2.0-notes.md`](docs/solid-2.0-notes.md).
+
+Commit messages carry the change rationale only — no tool/assistant attribution trailers. Don't add
+changesets or bump published-package versions until SolidJS 2.0 ships stable.
+
+## License
+
+MIT.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -1,0 +1,113 @@
+# @hope-ui/components
+
+The public, themed, accessible components of [hope-ui](../../README.md) for **SolidJS 2.0**. This
+is the product: components that look right out of the box under the default
+[`@hope-ui/presets/hope`](../presets/README.md) preset, styled with Tailwind v4 +
+`tailwind-variants`. Each component is a thin JSX layer over the headless
+[`@hope-ui/primitives`](../primitives/README.md) behavior kernel, computing its per-slot `class`
+from a recipe read through [`@hope-ui/theming`](../theming/README.md).
+
+Most apps consume this package. If you need behavior without hope-ui's styling, reach for
+`@hope-ui/primitives` directly (an advanced escape hatch, not the primary path).
+
+## Install
+
+> Not yet published — see the repo [status](../../README.md#status).
+
+```bash
+pnpm add @hope-ui/components @hope-ui/theming @hope-ui/presets
+```
+
+Peer dependencies: `solid-js` and `@solidjs/web` (both `2.0.0-beta.x`). Runtime dependencies on the
+sibling `@hope-ui/primitives` and `@hope-ui/theming` packages are carried for you.
+
+## Subpath exports
+
+There is **no root `.` export** — always import a specific component's subpath. Each subpath is its
+own build entry, so importing one component never pulls in another's code (`"sideEffects": false`
+keeps it tree-shakable).
+
+| Import | Component |
+| ------ | --------- |
+| `@hope-ui/components/button` | `Button` (+ `ButtonProps` and its variant vocabulary) |
+| `@hope-ui/components/dialog` | `Dialog` compound (`Dialog.Root`, `Dialog.Trigger`, `Dialog.Portal`, `Dialog.Backdrop`, `Dialog.Popup`, `Dialog.Title`, `Dialog.Description`, `Dialog.Close`) |
+| `@hope-ui/components/calendar` | `Calendar` compound |
+
+## Usage
+
+Wire the default preset once at the app root — import its Tailwind CSS entry into your Tailwind v4
+entry, and provide the preset object to `<ThemeProvider>`:
+
+```css
+/* your Tailwind entry, e.g. app.css */
+@import "tailwindcss";
+@import "@hope-ui/presets/hope/tailwind.css";
+```
+
+```tsx
+import { ThemeProvider } from "@hope-ui/theming";
+import { hope } from "@hope-ui/presets/hope";
+import { Button } from "@hope-ui/components/button";
+
+<ThemeProvider preset={hope}>
+  <Button colorScheme="danger" variant="soft">
+    Delete
+  </Button>
+</ThemeProvider>;
+```
+
+Compound components (Dialog) follow the parts model — every part except `Root` accepts a `render`
+prop for polymorphism, and open state is uncontrolled by default (`defaultOpen`) or controlled with
+`open`/`onOpenChange`:
+
+```tsx
+import { Dialog } from "@hope-ui/components/dialog";
+
+<Dialog.Root>
+  <Dialog.Trigger>Open</Dialog.Trigger>
+  <Dialog.Portal>
+    <Dialog.Backdrop />
+    <Dialog.Popup class="fixed inset-0 m-auto h-fit w-fit">
+      <Dialog.Title>Confirm</Dialog.Title>
+      <Dialog.Description>This can't be undone.</Dialog.Description>
+      <Dialog.Close>Cancel</Dialog.Close>
+    </Dialog.Popup>
+  </Dialog.Portal>
+</Dialog.Root>;
+```
+
+A modal `Dialog.Popup` must be positioned (`fixed`/`absolute`/`relative`), or it paints beneath the
+pointer-blocking backdrop — see [the Dialog usage doc](../../docs/usage/components/dialog/dialog.md).
+
+## Polymorphism: `render`, not `as`
+
+hope-ui deliberately avoids a generic `Polymorphic<T>`/`as`-prop type system. Components expose a
+function-only `render` prop wired through the kernel's `renderElement`, which also owns ref merging.
+`Button` additionally takes `nativeButton={false}` to switch to a `role="button"` accessibility
+model when you render a non-`<button>` element:
+
+```tsx
+<Button render={(props) => <a href="/next" {...props} />} nativeButton={false}>
+  Continue
+</Button>
+```
+
+## Composition rules
+
+- Compose behavior from `@hope-ui/primitives`; compute styling through `@hope-ui/theming`
+  (`useRecipe`/`useSlots`/`useDefaults`). A component never declares its own recipe contract — the
+  `RecipeRegistry` in theming is the single source of truth (no module augmentation).
+- **Never import from another component's subpath.** A higher-level component (e.g. Popover) must
+  compose the shared kernel directly — never `@hope-ui/components/dialog`, even when both are
+  "overlay-ish". This avoids the sibling-component coupling anti-pattern documented in
+  [`docs/plan.md`](../../docs/plan.md).
+
+## Docs
+
+- Per-component API, keyboard tables, and ARIA references: [`docs/usage/components/`](../../docs/usage/components/).
+- Theming model and semantic tokens: [`docs/theming.md`](../../docs/theming.md).
+- Component backlog and complexity tiers: [`docs/roadmap.md`](../../docs/roadmap.md).
+
+## License
+
+MIT.

--- a/packages/internal-test-utils/README.md
+++ b/packages/internal-test-utils/README.md
@@ -1,0 +1,44 @@
+# @hope-ui/internal-test-utils
+
+The shared test harness for [hope-ui](../../README.md). **Private and internal** — it is not
+published (`"private": true`), has no build step (consumers resolve its `src/` directly), and exists
+only so every workspace package's tests share one `mount` + a11y + hydration harness. Not part of
+the public API.
+
+Consumed by the tests of `@hope-ui/primitives`, `@hope-ui/theming`, and `@hope-ui/components` as a
+`workspace:*` dev dependency.
+
+## Exports
+
+| Export | Purpose |
+| ------ | ------- |
+| `mount(...)` | Renders a component into a detached, document-attached container (for the `browser` project). **Fails the test** on a `STRICT_READ_UNTRACKED` or `REACTIVE_WRITE_IN_OWNED_SCOPE` diagnostic — a deliberate untracked read must be spelled `untrack(...)`. Returns a `MountedComponent`. |
+| `expectNoA11yViolations(...)` | Runs axe-core against a mounted container. Fails on axe **violations** *and* on **`incomplete`** results; a genuinely undecidable check is named in `allowIncomplete` at the call site with a reason, never silenced by category. |
+| `hydrateFixture(...)` | Hydrates genuine server HTML and asserts no `console.error`/`console.warn`, no element added or dropped, and that every surviving node is the *same object* as the server's (so a silent client-render fallback can't masquerade as success). Returns a `HydratedComponent`. |
+
+Types `MountedComponent` and `HydratedComponent` are exported alongside.
+
+## Usage
+
+```tsx
+import { mount, expectNoA11yViolations } from "@hope-ui/internal-test-utils";
+
+it("has no a11y violations", async () => {
+  const { container } = mount(() => <Button>Save</Button>);
+  await expectNoA11yViolations(container);
+});
+```
+
+Every browser test that calls `mount()` must call `expectNoA11yViolations` at least once — this is
+enforced by `pnpm check:coverage-parity`.
+
+## Docs
+
+Per-helper docs: [`docs/usage/internal-test-utils/`](../../docs/usage/internal-test-utils/)
+(`mount`, `axe`). The testing stack, the three Vitest projects, and the hydration bridge are
+explained in [`docs/testing.md`](../../docs/testing.md); the enforced rules are in
+[`docs/definition-of-done.md`](../../docs/definition-of-done.md).
+
+## License
+
+MIT.

--- a/packages/presets/README.md
+++ b/packages/presets/README.md
@@ -1,0 +1,88 @@
+# @hope-ui/presets
+
+The visual identity for [hope-ui](../../README.md) — the concrete implementation of the
+[`@hope-ui/theming`](../theming/README.md) contract. It ships **`@hope-ui/presets/hope`** (a
+subpath export), the preset hope-ui is built and demoed against. The package is structured so a
+preset is one self-contained subpath.
+
+A preset has two halves that a consumer wires up together:
+
+1. **A CSS entry** imported into your Tailwind v4 entry — it ships the design tokens as `--hope-*`
+   CSS variables plus an `@theme inline` mapping to clean utilities (`bg-primary`, …).
+2. **A JS entry** — a `Preset` object you pass to `<ThemeProvider preset={…}>`, from which
+   `@hope-ui/components` reads each component's recipe.
+
+## Install
+
+> Not yet published — see the repo [status](../../README.md#status).
+
+```bash
+pnpm add @hope-ui/presets
+```
+
+Peer dependency: `tailwindcss` (`^4.0.0`). Depends *up* on `@hope-ui/theming` for the contract it
+implements.
+
+## Subpath exports
+
+| Import | Kind | Purpose |
+| ------ | ---- | ------- |
+| `@hope-ui/presets/hope` | JS | `hope` (the `Preset`) and `hopeRecipes` (the raw recipe map). |
+| `@hope-ui/presets/hope/tailwind.css` | CSS | The Tailwind v4 entry — `--hope-*` token values + the `@theme inline` mapping. |
+
+## Usage
+
+```css
+/* your Tailwind entry */
+@import "tailwindcss";
+@import "@hope-ui/presets/hope/tailwind.css";
+```
+
+```tsx
+import { ThemeProvider } from "@hope-ui/theming";
+import { hope } from "@hope-ui/presets/hope";
+
+<ThemeProvider preset={hope}>{/* app */}</ThemeProvider>;
+```
+
+`hope` is a **zero-DOM preset**: its token *values* are authored in CSS (`src/hope/tokens.css` —
+`:root` + `.dark`), so `<ThemeProvider preset={hope}>` renders no runtime token `<style>`. Dark mode
+is a `.dark` class. Theme is chosen at **build time** (which preset CSS you import); runtime
+theme-switching is possible via `data-theme`/`.dark` but out of scope for now.
+
+## How a preset is structured
+
+```
+src/
+├── _base/                # shared structural layer — reused unchanged by every preset (not a subpath)
+│   ├── variants.css      #   @custom-variant dark
+│   └── theme-map.css     #   @theme inline: --hope-* → Tailwind color namespace
+└── hope/
+    ├── index.ts          # the JS preset — definePreset over the recipe map (no token values here)
+    ├── tokens.css        # hope's --hope-* token values (:root + .dark)
+    ├── tailwind.css      # the published CSS entry — a thin orchestrator of @imports
+    └── recipes/          # tailwind-variants slot recipes; registered via @source
+```
+
+The `@theme inline` mapping and the `dark` variant are a pure function of the fixed semantic-token
+contract, so they live once in `_base/` rather than being copy-pasted per preset. A preset authors
+only its token *values* and its `recipes/`.
+
+## Swap-safety
+
+Raw scales (colors, spacing, radii) come from Tailwind itself, so their surface is identical in
+every build by construction. What each preset **must** define is the semantic vocabulary — every
+token in `SEMANTIC_COLOR_TOKENS` as a `--hope-*` variable, or a referencing utility compiles to an
+unresolved `var()`. Because CSS variables aren't `tsc`-checkable, this is enforced with
+`checkSemanticTokenConformance` (from [`@hope-ui/theming/conformance`](../theming/README.md)) run
+against the preset's token CSS read as a string — see `src/hope/__tests__/`.
+
+## Docs
+
+- Theming model, the two axes, and adding a preset: [`docs/theming.md`](../../docs/theming.md).
+- Preset API surface: [`docs/preset-api.md`](../../docs/preset-api.md).
+- Semantic-token reference: [`docs/usage/theming/semantic-tokens/semantic-tokens.md`](../../docs/usage/theming/semantic-tokens/semantic-tokens.md).
+
+## License
+
+MIT.

--- a/packages/primitives/README.md
+++ b/packages/primitives/README.md
@@ -1,0 +1,104 @@
+# @hope-ui/primitives
+
+The headless **behavior kernel** underneath [hope-ui](../../README.md): composable SolidJS 2.0
+primitives for rendering/polymorphism, focus management, dismissal, presence, collection & keyboard
+navigation, modality, and ARIA wiring. Everything else in the workspace composes it —
+[`@hope-ui/theming`](../theming/README.md) (for `createComponentContext`) and every
+[`@hope-ui/components`](../components/README.md) subpath.
+
+> **Internal / advanced escape hatch — not a stability-promised public API.** The kernel is shipped
+> so advanced consumers can build components hope-ui doesn't, but its signatures may churn between
+> minors; themed components are the marketed path, not headless composition. Treat these subpaths as
+> unstable.
+
+If a **true headless library** is what you're after — a stable, styling-agnostic API to build your
+own components on — reach for [Kobalte](https://github.com/kobaltedev/kobalte) instead. It's a
+mature, accessibility-first headless UI kit for SolidJS, and that's exactly the experience this
+kernel is *not* trying to provide.
+
+## Install
+
+> Not yet published — see the repo [status](../../README.md#status).
+
+```bash
+pnpm add @hope-ui/primitives
+```
+
+Peer dependencies: `solid-js` and `@solidjs/web` (`2.0.0-beta.x`), plus `@tanstack/virtual-core` as
+an **optional** peer (only `createVirtualCollection` needs it, so the kernel stays zero-cost for
+consumers who never virtualize). Bundled dependencies: `@internationalized/date` (the calendar
+substrate) and `@solid-primitives/a11y` (the live-region announcer).
+
+## Subpath exports
+
+Only top-level `src/` folders carry a barrel and a subpath — nothing deeper.
+
+| Import | Contents |
+| ------ | -------- |
+| `@hope-ui/primitives/utils` | Non-`createX` composition helpers: `renderElement` (the `render`/`as` polymorphism primitive + ref merging), `withDefaults` (the correct way to apply defaults under 2.0), `composeEventHandlers`, `createKeyboardHandler`, `runIfFunction`, `compareByIdOrReference`. |
+| `@hope-ui/primitives/internal` | The `createX` behavior primitives: `createComponentContext`, `createControllableState`, `createPresence`, `createFocusTrap`, `createFocusRestore`, `createHideOutside`, `createDismissable`, `createScrollLock`, `createRegisteredId`, `createRegisteredElement`, plus the list/grid/collection navigation family (`createCollection`, `createVirtualCollection`, `createListFocus`, `createListNavigation`, `createListSelection`, `createListTypeahead`, `createListExpansion`, `createGridNavigation`). |
+| `@hope-ui/primitives/dialog` | The `createDialog` hook family (root state + one hook per part). |
+| `@hope-ui/primitives/calendar` | The `createCalendar` hook family (headless month/year/decade calendar, built on `@internationalized/date`). |
+| `@hope-ui/primitives/modal-backdrop` | `ModalBackdrop` — the kernel's only DOM-rendering component, the pointer-blocking third of modality. |
+| `@hope-ui/primitives/i18n` | Locale + reading-direction context: `I18nProvider`, `useLocale`, `createDefaultLocale`, `getReadingDirection`, and message translation. |
+
+## Usage
+
+`renderElement` is the polymorphism + ref-merging primitive every public component routes its
+`as`/`render` surface through (modeled on Base UI's `useRender` idea, not its code):
+
+```tsx
+import { renderElement, withDefaults } from "@hope-ui/primitives/utils";
+
+function Separator(rawProps) {
+  const props = withDefaults(rawProps, { orientation: "horizontal" });
+  return renderElement("div", props, {
+    role: "separator",
+    "aria-orientation": props.orientation,
+  });
+}
+```
+
+Behavior primitives return state + spreadable props; the `createDialog` family, for example,
+decomposes into a root state hook plus one hook per part, so `@hope-ui/components`' `Dialog` is a
+thin JSX layer over it:
+
+```ts
+import { createDialog, createDialogPopup } from "@hope-ui/primitives/dialog";
+
+const state = createDialog({ modal: true });      // call once, in an owner scope
+const popup = createDialogPopup(state, props);     // owns the focus-trap/dismiss/scroll-lock stack
+```
+
+## Design notes worth knowing
+
+- **Modality is four mechanisms, not one.** `createHideOutside` applies `aria-hidden` **and**
+  `inert` outside the popup; `createFocusTrap` cycles Tab inside it; `ModalBackdrop` blocks the
+  pointer unconditionally. None is redundant — see [`CLAUDE.md`](../../CLAUDE.md) and the
+  [`modal-backdrop` usage doc](../../docs/usage/primitives/modal-backdrop/modal-backdrop.md).
+- **No primitive keeps cross-instance state at module scope.** `createScrollLock` and
+  `createHideOutside` key their ref counts off `document.body`/the element under a `Symbol.for(...)`,
+  which resolves through the cross-realm global symbol registry, so two installed copies read the
+  same slot.
+- **SolidJS 2.0 idioms are load-bearing.** Split `createEffect(depsFn, computeFn)`, `merge`/`omit`
+  (not `mergeProps`/`splitProps`), `onSettled` (not `onMount`), `withDefaults` (not `merge`) for
+  defaults. See [`docs/solid-2.0-notes.md`](../../docs/solid-2.0-notes.md).
+
+## Reference / composition policy
+
+Base UI and React Aria are active behavior references (public API + a11y reasoning, not their React
+internals). `@solid-primitives` (the `next` branch) is adopted as a dependency where it fits, gated
+on the full Definition of Done — above all the hydration round-trip. Do **not** copy code from other
+Solid headless libraries. See [`docs/reference-implementations.md`](../../docs/reference-implementations.md)
+and [`docs/solid-primitives-eval.md`](../../docs/solid-primitives-eval.md).
+
+## Docs
+
+Per-primitive usage docs live under [`docs/usage/primitives/`](../../docs/usage/primitives/). The
+composed families (`dialog`, `calendar`, `i18n`, `modal-backdrop`) and `utils/` helpers each carry a
+usage `.md`; the `internal/` behavior primitives require a test but not a consumer-facing doc.
+Architecture rationale: [`docs/plan.md`](../../docs/plan.md).
+
+## License
+
+MIT.

--- a/packages/theming/README.md
+++ b/packages/theming/README.md
@@ -1,0 +1,91 @@
+# @hope-ui/theming
+
+The **theming contract** and dependency-inversion seam for [hope-ui](../../README.md).
+[`@hope-ui/components`](../components/README.md) reads recipes *from* it;
+[`@hope-ui/presets`](../presets/README.md) implement *it*; neither package knows about the other.
+It owns the look-&-feel contract (the closed, hand-declared `RecipeRegistry`), the semantic-token
+vocabulary, and the Tailwind styling seam.
+
+It depends on [`@hope-ui/primitives`](../primitives/README.md) for `createComponentContext` — which
+is why primitives can't fold into components (that would make a `components → theming → components`
+cycle).
+
+## Install
+
+> Not yet published — see the repo [status](../../README.md#status).
+
+```bash
+pnpm add @hope-ui/theming
+```
+
+Peer dependencies: `solid-js` and `@solidjs/web` (`2.0.0-beta.x`). Bundled: `tailwind-variants` and
+`tailwind-merge` (the styling seam).
+
+## Subpath exports
+
+| Import | Contents |
+| ------ | -------- |
+| `@hope-ui/theming` | The contract kernel: `ThemeProvider`/`useRecipe`/`useDefaults`/`useSlots`/`useTheme`; `definePreset`/`isPreset` and the `Preset` type; the `RecipeRegistry` + `ThemeablePropsRegistry` types and `THEMING_CONTRACT_VERSION`; `SlotRecipeFn`/`SlotClassFn` and each component's recipe/themeable-props types; `SEMANTIC_COLOR_TOKENS` + `SemanticColorContract`; and the `tv`/`cn`/`cx` styling helpers. |
+| `@hope-ui/theming/conformance` | A generic runtime conformance kit — `checkSlotRecipeConformance`/`assertSlotRecipeConformance` (recipe axis) and `checkSemanticTokenConformance`/`assertSemanticTokenConformance` (token axis). Kept off the main subpath so it never enters a runtime consumer's bundle. |
+
+## How it works
+
+- **`ThemeProvider` / `useRecipe`.** `<ThemeProvider preset={…}>` injects a preset into context;
+  a component reads one recipe out with `useRecipe("<name>")` and computes its slot classes in a
+  getter. Built on the isomorphic `createComponentContext`, so it is server-readable during
+  `renderToStringAsync` — that is the whole of "works in SolidStart" for theming. The provider
+  renders no DOM of its own.
+- **`RecipeRegistry`.** The single source of truth for every hope-authored component's recipe
+  (variant vocabulary + slots). A component does **not** `declare module` its own recipe — both the
+  component and every preset import the contract types from here (no module augmentation).
+- **Every recipe is a slot recipe.** There is no single-class form; a one-part component uses the
+  `root` slot, so a caller always deals in `recipe(props).<slot>()`.
+- **`defaultProps` + `ThemeablePropsRegistry`.** A preset can default a component's *themeable-props
+  surface* (recipe variants plus reuse-safe chrome factories) app-wide; `useDefaults` merges them at
+  `instance ?? preset ?? builtin` precedence. The registry is intentionally non-exhaustive.
+- **Semantic tokens.** `SEMANTIC_COLOR_TOKENS` is the design-system-agnostic role vocabulary every
+  preset implements (`primary`, `surface`, `foreground`, `on-primary`, `focus`, `scrim`, …), read as
+  Tailwind utilities (`bg-primary`, `text-on-primary`). Because presets ship CSS variables rather
+  than typed objects, completeness is enforced at the CSS level by the conformance kit, not by `tsc`.
+
+## Usage
+
+Reading a recipe inside a component (`button` is the recipe registered today):
+
+```tsx
+import { useRecipe } from "@hope-ui/theming";
+import { renderElement } from "@hope-ui/primitives/utils";
+
+function Button(props) {
+  const recipe = useRecipe("button");
+  return renderElement("button", props, {
+    get class() {
+      return recipe(props).root({ class: props.class });
+    },
+  });
+}
+```
+
+Declaring a **new** component's contract (in this package, then implemented by each preset):
+
+```ts
+// recipes/accordion.ts
+export interface AccordionRecipeVariants { size?: "sm" | "md"; }
+export type AccordionSlot = "root" | "item" | "trigger";
+
+// registry/recipe-registry.ts
+interface RecipeRegistry {
+  accordion: SlotRecipeFn<AccordionRecipeVariants, AccordionSlot>;
+}
+```
+
+## Docs
+
+Per-symbol API detail lives under [`docs/usage/theming/`](../../docs/usage/theming/) (including the
+authoritative [semantic-token reference](../../docs/usage/theming/semantic-tokens/semantic-tokens.md)).
+The orientation doc — the two axes, the contract, and how a preset implements it — is
+[`docs/theming.md`](../../docs/theming.md).
+
+## License
+
+MIT.


### PR DESCRIPTION
Root README (overview, status, package map, getting started, dev commands, layout, contributing) plus a README for each workspace package, and a root MIT LICENSE.md.